### PR TITLE
Revert "input: synaptics: s3320: Remove wild msleeps from init"

### DIFF
--- a/drivers/input/touchscreen/synaptics_driver_s3320.c
+++ b/drivers/input/touchscreen/synaptics_driver_s3320.c
@@ -3684,6 +3684,7 @@ static int synaptics_ts_probe(struct i2c_client *client, const struct i2c_device
         ret = pinctrl_select_state(ts->pinctrl,
                 ts->pinctrl_state_active);
         }
+    msleep(100);//after power on tp need sometime from bootloader to ui mode
 	mutex_init(&ts->mutex);
 	mutex_init(&ts->mutexreport);
     atomic_set(&ts->irq_enable,0);
@@ -3810,6 +3811,7 @@ static int synaptics_ts_probe(struct i2c_client *client, const struct i2c_device
             TPD_ERR("unable to request gpio [%d]\n",ts->irq_gpio);
         }
         ret = gpio_direction_input(ts->irq_gpio);
+        msleep(50);
         ts->irq = gpio_to_irq(ts->irq_gpio);
 	}
 	TPD_ERR("synaptic:ts->irq is %d\n",ts->irq);
@@ -3820,6 +3822,7 @@ static int synaptics_ts_probe(struct i2c_client *client, const struct i2c_device
 			TPD_DEVICE, ts);
 	if(ret < 0)
 		TPD_ERR("%s request_threaded_irq ret is %d\n",__func__,ret);
+    msleep(5);
 	ret = synaptics_enable_interrupt(ts, 1);
 	if(ret < 0)
 		TPD_ERR("%s enable interrupt error ret=%d\n",__func__,ret);


### PR DESCRIPTION
Removing these causes non-stop i2c errors from the touchscreen controller
when booting the device and not touching it for a few minutes. The errors
don't seem to have any serious implications, but it's better to not see
them at all.

This reverts commit 12d9345d046e82189b3eef45738a1164907d4ce0.

Change-Id: Ie9cf9f29c295d420d8b4f9f4eff001b55ac64ee4